### PR TITLE
Updates for Ember 2.x compatibility

### DIFF
--- a/app/adapters/cordova-contact.js
+++ b/app/adapters/cordova-contact.js
@@ -106,7 +106,7 @@ export default DS.Adapter.extend({
    */
   findAll: function (store, type, sinceToken) {
     return contactsLib().then(function (cdvContacts) {
-      var options = {filter: '', multiple: true, desiredFields: ['displayName', 'phoneNumbers'], hasPhoneNumber: true};
+      var options = {filter: '', multiple: true, hasPhoneNumber: true};
       return new Ember.RSVP.Promise(function (resolve, reject) {
         cdvContacts.find(
           [cdvContacts.fieldType.id],
@@ -127,7 +127,7 @@ export default DS.Adapter.extend({
       return new Ember.RSVP.Promise(function (resolve, reject) {
         var options, parsedQuery;
         parsedQuery = parseQuery(query, cdvContacts);
-        options = {filter: parsedQuery.filter, multiple: true, desiredFields: ['displayName', 'phoneNumbers'], hasPhoneNumber: true};
+        options = {filter: parsedQuery.filter, multiple: true, hasPhoneNumber: true};
         cdvContacts.find(
           parsedQuery.fields,
           function (contacts) {

--- a/app/adapters/cordova-contact.js
+++ b/app/adapters/cordova-contact.js
@@ -106,7 +106,7 @@ export default DS.Adapter.extend({
    */
   findAll: function (store, type, sinceToken) {
     return contactsLib().then(function (cdvContacts) {
-      var options = {filter: '', multiple: true};
+      var options = {filter: '', multiple: true, desiredFields: ['displayName', 'phoneNumbers'], hasPhoneNumber: true};
       return new Ember.RSVP.Promise(function (resolve, reject) {
         cdvContacts.find(
           [cdvContacts.fieldType.id],

--- a/app/adapters/cordova-contact.js
+++ b/app/adapters/cordova-contact.js
@@ -106,7 +106,7 @@ export default DS.Adapter.extend({
    */
   findAll: function (store, type, sinceToken) {
     return contactsLib().then(function (cdvContacts) {
-      var options = {filter: '', multiple: true, hasPhoneNumber: true};
+      var options = {filter: '', multiple: true, hasPhoneNumber: true, desiredFields: [navigator.contacts.fieldType.name, navigator.contacts.fieldType.phoneNumbers, navigator.contacts.fieldType.displayName]};
       return new Ember.RSVP.Promise(function (resolve, reject) {
         cdvContacts.find(
           [cdvContacts.fieldType.id],

--- a/app/adapters/cordova-contact.js
+++ b/app/adapters/cordova-contact.js
@@ -122,7 +122,7 @@ export default DS.Adapter.extend({
   /**
    * @inheritDoc
    */
-  findQuery: function (store, type, query/*, recordArray*/) {
+  query: function (store, type, query/*, recordArray*/) {
     return contactsLib().then(function (cdvContacts) {
       return new Ember.RSVP.Promise(function (resolve, reject) {
         var options, parsedQuery;

--- a/app/adapters/cordova-contact.js
+++ b/app/adapters/cordova-contact.js
@@ -127,7 +127,7 @@ export default DS.Adapter.extend({
       return new Ember.RSVP.Promise(function (resolve, reject) {
         var options, parsedQuery;
         parsedQuery = parseQuery(query, cdvContacts);
-        options = {filter: parsedQuery.filter, multiple: true};
+        options = {filter: parsedQuery.filter, multiple: true, desiredFields: ['displayName', 'phoneNumbers'], hasPhoneNumber: true};
         cdvContacts.find(
           parsedQuery.fields,
           function (contacts) {

--- a/app/models/cordova-contact.js
+++ b/app/models/cordova-contact.js
@@ -41,7 +41,7 @@ export default DS.Model.extend({
    * @property anyName
    * @type {string}
    */
-  anyName: Ember.computed.any('displayName', 'nickname', 'name.formatted'),
+  anyName: Ember.computed.or('displayName', 'nickname', 'name.formatted'),
 
   /**
    * First available picture

--- a/app/transforms/cordova-basic-array.js
+++ b/app/transforms/cordova-basic-array.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
 import Ember from 'ember';
+import map from 'lodash/collection/map';
 
 /**
  * @class CordovaBasicArrayTransform
@@ -8,7 +9,7 @@ import Ember from 'ember';
 export default DS.Transform.extend({
   deserialize: function (serialized) {
     return Ember.ArrayProxy.create({
-      content: serialized ? Ember.EnumerableUtils.map(serialized, function (item) {
+      content: serialized ? map(serialized, function (item) {
         return Ember.ObjectProxy.create({content: item || {}});
       }) : []
     });

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "express": "^4.8.5",
     "glob": "^4.0.5"
   },
+  "dependencies": {
+    "ember-lodash": "0.0.3"
+  },
   "keywords": [
     "ember-addon",
     "cordova",


### PR DESCRIPTION
1. Ember.EnumerableUtils.map was deprecated in 1.10 and removes in 2.0.0. Replaced with ember-lodash
2. Ember.computed.any is gone. Replaced with Ember.computed.or
